### PR TITLE
(SLV-441) Configure nginx to serve gatling repos

### DIFF
--- a/site-modules/gplt_runner_setup/manifests/core.pp
+++ b/site-modules/gplt_runner_setup/manifests/core.pp
@@ -46,7 +46,22 @@ class gplt_runner_setup::core (
     package => "java-1.8.0-openjdk-devel",
   }
 
-  include nginx
+  class { "nginx":
+    manage_repo    => true,
+    package_source => "nginx-stable",
+    confd_only     => true,
+  }
+
+  nginx::resource::server{ "default":
+    www_root => "/usr/share/nginx/html/users",
+    autoindex => "on",
+  }
+
+  file { "html users":
+    ensure => "directory",
+    path   => "/usr/share/nginx/html/users",
+    mode   => "755",
+  }
 
   include pdk
 

--- a/site-modules/gplt_runner_setup/manifests/user_setup.pp
+++ b/site-modules/gplt_runner_setup/manifests/user_setup.pp
@@ -19,6 +19,12 @@ class gplt_runner_setup::user_setup (
     managehome       => true,
   }
 
+  file { "${test_user} home":
+    ensure => "directory",
+    path   => "/home/${test_user}",
+    mode   => "755",
+  }
+
   file { "${test_user} ssh":
     ensure  => "directory",
     path    => "/home/${test_user}/.ssh",
@@ -49,6 +55,12 @@ class gplt_runner_setup::user_setup (
     path   => "/home/${test_user}/gatling",
     owner  => $test_user,
     group  => $test_user,
+  }
+
+  file { "${test_user} html users link":
+    ensure => "link",
+    path   => "/usr/share/nginx/html/users/${test_user}",
+    target => "/home/${test_user}/gatling"
   }
 
   include gplt_runner_setup::sudo


### PR DESCRIPTION
Set autoindex on so we can navigator directories
created /usr/share/nginx/html/users/ to hold links to users gatling directories.
Setup nginx to open to that dir by default