### PR TITLE
(SLV-585) install latest bolt

### DIFF
--- a/site-modules/gplt_runner_setup/manifests/core.pp
+++ b/site-modules/gplt_runner_setup/manifests/core.pp
@@ -75,7 +75,7 @@ class gplt_runner_setup::core (
   }
 
   package { "puppet-bolt":
-    ensure => "1.15.0-1.el7",
+    ensure => "present",
   }
 
   exec { "pip":


### PR DESCRIPTION
updated code to install the lastest bolt rather than 1.15.  1.15 is needed to run the plan, but doesn't need to be on the box this plan configures.  And the pe_xl module used by gplt doesn't work with 1.15